### PR TITLE
add e18 to the token issuance

### DIFF
--- a/packages/contracts/contracts/LQTY/CommunityIssuance.sol
+++ b/packages/contracts/contracts/LQTY/CommunityIssuance.sol
@@ -75,7 +75,7 @@ contract CommunityIssuance is ICommunityIssuance, Ownable, CheckContract, BaseMa
     function issueLQTY() external override returns (uint) {
         _requireCallerIsStabilityPool();
 
-        uint latestTotalLQTYIssued = block.timestamp.sub(deploymentTime).div(SECONDS_IN_ONE_MINUTE);
+        uint latestTotalLQTYIssued = block.timestamp.sub(deploymentTime).div(SECONDS_IN_ONE_MINUTE).mul(DECIMAL_PRECISION);
         uint issuance = latestTotalLQTYIssued.sub(totalLQTYIssued);
 
         totalLQTYIssued = latestTotalLQTYIssued;


### PR DESCRIPTION
I forgot to multiply the number of minutes by 10e18 in order to account for the precision